### PR TITLE
删除文章后，action_text_rich_texts 表对应数据未自动删除

### DIFF
--- a/lib/actiontext-lite/attribute.rb
+++ b/lib/actiontext-lite/attribute.rb
@@ -18,7 +18,9 @@ module ActionTextLite
           end
         CODE
 
-        has_one :"rich_text_#{name}", -> { where(name: name) }, class_name: "ActionTextLite::RichText", as: :record, inverse_of: :record
+        has_one :"rich_text_#{name}", -> { where(name: name) },
+                class_name: "ActionTextLite::RichText", as: :record, inverse_of: :record, autosave: true, dependent: :destroy
+            
         scope :"with_rich_text_#{name}", -> { includes("rich_text_#{name}") }
 
         after_save do


### PR DESCRIPTION
参考了 ActionText 的官方源码，修改如上